### PR TITLE
Added a new "ignoreDTD" option to avoid DTD validations while opening an XML file

### DIFF
--- a/src/UnitTests/UnitTest1.cs
+++ b/src/UnitTests/UnitTest1.cs
@@ -2333,7 +2333,7 @@ Prefix 'user' is not defined. ");
             XmlDocument doc = new XmlDocument();
             doc.Load(test);
             XmlReaderSettings settings = new XmlReaderSettings();
-            settings.ProhibitDtd = false;
+            settings.DtdProcessing = DtdProcessing.Prohibit;
             foreach (XmlElement e in doc.SelectNodes("test/case")) {
                 Uri input = new Uri(baseUri, e.GetAttribute("input"));
                 Uri output = new Uri(baseUri, e.GetAttribute("results"));

--- a/src/XmlNotepad/FormMain.cs
+++ b/src/XmlNotepad/FormMain.cs
@@ -315,6 +315,7 @@ namespace XmlNotepad {
             this.settings["AppRegistered"] = false;
             this.settings["MaximumLineLength"] = 10000;
             this.settings["AutoFormatLongLines"] = false;
+            this.settings["IgnoreDTD"] = false;
 
             this.settings.Changed += new SettingsEventHandler(settings_Changed);
 

--- a/src/XmlNotepad/FormOptions.cs
+++ b/src/XmlNotepad/FormOptions.cs
@@ -186,6 +186,7 @@ namespace XmlNotepad
         string language;
         int maximumLineLength;
         bool autoFormatLongLines;
+        bool ignoreDTD;
 
         public UserSettings(Settings s) {            
             this.settings = s;
@@ -210,6 +211,7 @@ namespace XmlNotepad
             language = (string)this.settings["Language"];
             maximumLineLength = (int)this.settings["MaximumLineLength"];
             autoFormatLongLines = (bool)this.settings["AutoFormatLongLines"];
+            ignoreDTD = (bool)this.settings["IgnoreDTD"];
         }
 
         public static string Escape(string nl) {
@@ -243,6 +245,7 @@ namespace XmlNotepad
             this.settings["Language"] = ("" + this.language).Trim();
             this.settings["MaximumLineLength"] = this.maximumLineLength;
             this.settings["AutoFormatLongLines"] = this.autoFormatLongLines;
+            this.settings["IgnoreDTD"] = this.ignoreDTD;
 
             this.settings.OnChanged("Colors");
 
@@ -266,6 +269,7 @@ namespace XmlNotepad
             newLineChars = Escape("\r\n");
             language = "";
             this.maximumLineLength = 10000;
+            ignoreDTD = false;
         }
 
         [SRCategoryAttribute("ColorCategory")]
@@ -486,6 +490,21 @@ namespace XmlNotepad
             set
             {
                 this.autoFormatLongLines = value;
+            }
+        }
+
+        [SRCategoryAttribute("Validation")]
+        [LocDisplayName("IgnoreDTDProperty")]
+        [SRDescriptionAttribute("IgnoreDTDDescription")]
+        public bool IgnoreDTD
+        {
+            get
+            {
+                return this.ignoreDTD;
+            }
+            set
+            {
+                this.ignoreDTD = value;
             }
         }
     }

--- a/src/XmlNotepad/SR.resx
+++ b/src/XmlNotepad/SR.resx
@@ -718,4 +718,12 @@ Do you want to visit the web page that describes this update?</value>
     <value>XML files (*.xml)|*.xml|XSL files (*.xsl)|*.xsl|XSD files (*.xsd)|*.xsd|CSV files (*.csv)|*.csv|All files (*.*)|*.*</value>
     <comment>Open file dialog filter.</comment>
   </data>
+  <data name="IgnoreDTDDescription" xml:space="preserve">
+    <value>Avoid DTD validations</value>
+    <comment>Property Grid Description</comment>
+  </data>
+  <data name="IgnoreDTDProperty" xml:space="preserve">
+    <value>Ignore DTD</value>
+    <comment>Property Grid Property Name</comment>
+  </data>
 </root>

--- a/src/XmlNotepad/StringResources.Designer.cs
+++ b/src/XmlNotepad/StringResources.Designer.cs
@@ -603,6 +603,24 @@ namespace XmlNotepad {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Avoid DTD validations.
+        /// </summary>
+        internal static string IgnoreDTDDescription {
+            get {
+                return ResourceManager.GetString("IgnoreDTDDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ignore DTD.
+        /// </summary>
+        internal static string IgnoreDTDProperty {
+            get {
+                return ResourceManager.GetString("IgnoreDTDProperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Illegal surrogate character pair 0x{0}, 0x{1} at position {2} in this text node..
         /// </summary>
         internal static string IllegalSurrogatePair {

--- a/src/XmlNotepad/XmlCache.cs
+++ b/src/XmlNotepad/XmlCache.cs
@@ -234,7 +234,7 @@ namespace XmlNotepad
 
         internal XmlReaderSettings GetReaderSettings() {
             XmlReaderSettings settings = new XmlReaderSettings();
-            settings.ProhibitDtd = false;
+            settings.DtdProcessing = GetSettingBoolean("IgnoreDTD") ? DtdProcessing.Ignore : DtdProcessing.Parse;
             settings.CheckCharacters = false;
             settings.XmlResolver = new XmlProxyResolver(this.site);
             return settings;
@@ -244,7 +244,7 @@ namespace XmlNotepad
             if (this.Document != null) {
                 this.dirty = true;
                 XmlReaderSettings s = new XmlReaderSettings();
-                s.ProhibitDtd = false;
+                s.DtdProcessing = GetSettingBoolean("IgnoreDTD") ? DtdProcessing.Ignore : DtdProcessing.Parse;
                 s.XmlResolver = new XmlProxyResolver(this.site);
                 using (XmlReader r = XmlIncludeReader.CreateIncludeReader(this.Document, s, this.FileName)) {
                     this.Document = loader.Load(r);
@@ -630,6 +630,23 @@ namespace XmlNotepad
             GC.SuppressFinalize(this);
         }
 
+        public bool GetSettingBoolean(string settingName)
+        {
+            if (this.site != null)
+            {
+                Settings settings = (Settings)this.site.GetService(typeof(Settings));
+                if (settings != null)
+                {
+                    object settingValue = settings[settingName];
+                    if (settingValue is bool)
+                    {
+                        return (bool)settingValue;
+                    }
+                }
+            }
+
+            return false;
+        }
     }
 
     public enum ModelChangeType

--- a/src/XmlNotepad/XsltViewer.cs
+++ b/src/XmlNotepad/XsltViewer.cs
@@ -186,7 +186,7 @@ namespace XmlNotepad {
                         this.loaded = DateTime.Now;
                         settings.EnableScript = (trusted.ContainsKey(resolved));
                         XmlReaderSettings rs = new XmlReaderSettings();
-                        rs.ProhibitDtd = false;
+                        rs.DtdProcessing = model.GetSettingBoolean("IgnoreDTD") ? DtdProcessing.Ignore : DtdProcessing.Parse;
                         rs.XmlResolver = resolver;
                         using (XmlReader r = XmlReader.Create(resolved.AbsoluteUri, rs)) {
                             xslt.Load(r, settings, resolver);
@@ -198,7 +198,7 @@ namespace XmlNotepad {
                     StringWriter writer = new StringWriter();
                     XmlReaderSettings settings = new XmlReaderSettings();
                     settings.XmlResolver = new XmlProxyResolver(this.site);
-                    settings.ProhibitDtd = false;
+                    settings.DtdProcessing = model.GetSettingBoolean("IgnoreDTD") ? DtdProcessing.Ignore : DtdProcessing.Parse;
                     transform.Transform(XmlIncludeReader.CreateIncludeReader(context, settings, GetBaseUri().AbsoluteUri), null, writer);
                     this.xsltUri = resolved;                       
                     Display(writer.ToString());


### PR DESCRIPTION
Sometimes the user might just want to ignore the DTD's being validated. Currently, the application will not open an XML file whose DTDs could not be validated. With the new option, user can avoid this validation.
Default=False (existing behaviour).

![ignoredtd-option](https://cloud.githubusercontent.com/assets/1557108/24200278/ae4adb88-0f32-11e7-9e25-2e7a890852f8.PNG)
