### PR TITLE
New setting to specify the MaximumValueLength

### DIFF
--- a/src/XmlNotepad/FormMain.cs
+++ b/src/XmlNotepad/FormMain.cs
@@ -314,6 +314,7 @@ namespace XmlNotepad {
 
             this.settings["AppRegistered"] = false;
             this.settings["MaximumLineLength"] = 10000;
+            this.settings["MaximumValueLength"] = short.MaxValue;
             this.settings["AutoFormatLongLines"] = false;
             this.settings["IgnoreDTD"] = false;
 

--- a/src/XmlNotepad/FormOptions.cs
+++ b/src/XmlNotepad/FormOptions.cs
@@ -185,6 +185,7 @@ namespace XmlNotepad
         string newLineChars;
         string language;
         int maximumLineLength;
+        int maximumValueLength;
         bool autoFormatLongLines;
         bool ignoreDTD;
 
@@ -244,6 +245,7 @@ namespace XmlNotepad
 
             this.settings["Language"] = ("" + this.language).Trim();
             this.settings["MaximumLineLength"] = this.maximumLineLength;
+            this.settings["MaximumValueLength"] = this.maximumValueLength;
             this.settings["AutoFormatLongLines"] = this.autoFormatLongLines;
             this.settings["IgnoreDTD"] = this.ignoreDTD;
 
@@ -269,6 +271,7 @@ namespace XmlNotepad
             newLineChars = Escape("\r\n");
             language = "";
             this.maximumLineLength = 10000;
+            this.maximumValueLength = short.MaxValue;
             ignoreDTD = false;
         }
 
@@ -475,6 +478,21 @@ namespace XmlNotepad
             set
             {
                 this.maximumLineLength = value;
+            }
+        }
+
+        [SRCategoryAttribute("LongLineCategory")]
+        [LocDisplayName("MaximumValueLengthProperty")]
+        [SRDescriptionAttribute("MaximumValueLengthDescription")]
+        public int MaximumValueLength
+        {
+            get
+            {
+                return this.maximumValueLength;
+            }
+            set
+            {
+                this.maximumValueLength = value;
             }
         }
 

--- a/src/XmlNotepad/NodeTextView.cs
+++ b/src/XmlNotepad/NodeTextView.cs
@@ -41,7 +41,7 @@ namespace XmlNotepad {
             InitializeComponent();
 
             this.SuspendLayout();
-            this.editor = new TextEditorOverlay(this);
+            this.editor = new TextEditorOverlay(this, (int)settings["MaximumLineLength"]);
             this.editor.MultiLine = true;
             this.editor.CommitEdit += new EventHandler<TextEditorEventArgs>(OnCommitEdit);
             this.editor.LayoutEditor += new EventHandler<TextEditorLayoutEventArgs>(OnLayoutEditor);

--- a/src/XmlNotepad/SR.resx
+++ b/src/XmlNotepad/SR.resx
@@ -228,7 +228,7 @@ Would you like to reformat the text into multiple lines?</value>
     <comment>Message box prompt</comment>
   </data>
   <data name="MainFormTitle" xml:space="preserve">
-    <value>XML Notepad</value>
+    <value>XML Notepad MaxLength Extended</value>
     <comment>Window title</comment>
   </data>
   <data name="MoveErrorCaption" xml:space="preserve">
@@ -704,6 +704,14 @@ Do you want to visit the web page that describes this update?</value>
   </data>
   <data name="MaximumLineLengthProperty" xml:space="preserve">
     <value>Maximum Line Length</value>
+    <comment>Property Grid property name</comment>
+  </data>
+  <data name="MaximumValueLengthDescription" xml:space="preserve">
+    <value>What is the maximum length for the textbox</value>
+    <comment>Property Grid description</comment>
+  </data>
+  <data name="MaximumValueLengthProperty" xml:space="preserve">
+    <value>Maximum Value Length</value>
     <comment>Property Grid property name</comment>
   </data>
   <data name="NoByteOrderMark" xml:space="preserve">

--- a/src/XmlNotepad/StringResources.Designer.cs
+++ b/src/XmlNotepad/StringResources.Designer.cs
@@ -19,7 +19,7 @@ namespace XmlNotepad {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SR {
@@ -805,7 +805,7 @@ namespace XmlNotepad {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to XML Notepad.
+        ///   Looks up a localized string similar to XML Notepad MaxLength Extended.
         /// </summary>
         internal static string MainFormTitle {
             get {
@@ -828,6 +828,24 @@ namespace XmlNotepad {
         internal static string MaximumLineLengthProperty {
             get {
                 return ResourceManager.GetString("MaximumLineLengthProperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to What is the maximum length for the textbox.
+        /// </summary>
+        internal static string MaximumValueLengthDescription {
+            get {
+                return ResourceManager.GetString("MaximumValueLengthDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Maximum Value Length.
+        /// </summary>
+        internal static string MaximumValueLengthProperty {
+            get {
+                return ResourceManager.GetString("MaximumValueLengthProperty", resourceCulture);
             }
         }
         

--- a/src/XmlNotepad/TextEditorOverlay.cs
+++ b/src/XmlNotepad/TextEditorOverlay.cs
@@ -69,7 +69,7 @@ namespace XmlNotepad {
         public event EventHandler<TextEditorEventArgs> CommitEdit;
         public event EventHandler<TextEditorLayoutEventArgs> LayoutEditor;
 
-        public TextEditorOverlay(Control parent) {
+        public TextEditorOverlay(Control parent, int maxLength = short.MaxValue) {
             this.parent = parent;
             this.textEditor = new TextBox();
             string name = parent.Name + "Editor"; 
@@ -82,6 +82,7 @@ namespace XmlNotepad {
             this.textEditor.Multiline = true; // this fixes layout problems in single line case also.
             this.textEditor.Margin = new Padding(1, 0, 0, 0);
             this.textEditor.HideSelection = false;
+            this.textEditor.MaxLength = maxLength;
             parent.Controls.Add(this.textEditor);
             this.textEditor.KeyDown += new KeyEventHandler(editor_KeyDown);
             this.textEditor.LostFocus += new EventHandler(editor_LostFocus);


### PR DESCRIPTION
A new setting MaximumValueLength has been implemented to override the existing maxlength (32767) in the editable textbox