### PR TITLE
Fixed build issue, where VS2017 presented me with build error CS0121

### DIFF
--- a/src/XmlNotepad/FormMain.cs
+++ b/src/XmlNotepad/FormMain.cs
@@ -327,6 +327,7 @@ namespace XmlNotepad {
             this.settings["SchemaCache"] = this.model.SchemaCache;
 
             System.Threading.Tasks.Task.Run(CheckNetwork);
+            System.Threading.Tasks.Task.Run((Action)CheckNetwork);
         }
 
         private void CheckNetwork()


### PR DESCRIPTION
It seems that in the `System.Threading.Tasks.Task.Run(CheckNetwork);` line of code, upon compilation in **Visual Studio 2017**, I was presented with _build error **CS0121**_.

Casting the parameter (`CheckNetwork`) to type `Action` fixed the build error.

The final result is that the line of code is now as follows:
`System.Threading.Tasks.Task.Run((Action)CheckNetwork);`