### PR TITLE
PasteCommand was updated to call validation only one time

### DIFF
--- a/src/XmlNotepad/Commands.cs
+++ b/src/XmlNotepad/Commands.cs
@@ -2321,10 +2321,6 @@ namespace XmlNotepad
             }
             this.position = position;
             this.view = view;
-            if (td != null)
-            {
-                this.source = td.GetTreeNode(this.doc, this.target, this.view);
-            }
         }
 
         public XmlTreeNode NewNode { get { return this.source; } }
@@ -2340,9 +2336,14 @@ namespace XmlNotepad
 
         public override void Do()
         {
-
             if (td != null)
             {
+                this.view.Model.BeginUpdate();
+                if (this.source == null)
+                {
+                    this.source = td.GetTreeNode(this.doc, this.target, this.view);
+                }
+
                 InsertNode icmd = new InsertNode(this.view);
                 icmd.Initialize(source, this.target, position);
                 this.cmd = icmd;
@@ -2351,6 +2352,8 @@ namespace XmlNotepad
                 {
                     this.source.Expand();
                 }
+
+                this.view.Model.EndUpdate();
             }
         }
 


### PR DESCRIPTION
As I understand the main problem is that when we paste XmlTree then the validation will be called for every element of this XmlTree. The main idea of my fix is to call validation only once for PasteCommand.

Close #82 
Close #170 