### PR TITLE
Update willy.xsl

### DIFF
--- a/src/Application/Samples/willy.xsl
+++ b/src/Application/Samples/willy.xsl
@@ -1,4 +1,3 @@
-<!-- XSL designed to provide HTML output from Jon Bosak's Shakespeare XML collection -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
   <xsl:template match="/">
     <html>
@@ -8,9 +7,14 @@
         </title>
         <style>
           body, td, th { font-family:Verdana, Arial, helvetica, sans-serif; font-size:x-small; }
+          body { background-color:#EEEEEE; }
+          h1, h2 { text-align:center; }
+          .act-title { background-color:teal; color:white; padding:4px; }
+          .speaker { font-weight:bold; color:black; }
+          .stage-dir { font-style:italic; color:black; }
         </style>
       </head>
-      <body STYLE=" background-color:#EEEEEE">
+      <body>
         <!-- Display title and author of play -->
         <center>
           <h1>
@@ -24,14 +28,16 @@
       </body>
     </html>
   </xsl:template>
+  
   <xsl:template match="ACT">
-    <DIV STYLE="background-color:teal; color:white; padding:4px">
-      <SPAN STYLE="font-weight:bold; color:white">
-        <xsl:value-of select="TITLE" />: <xsl:value-of select="TITLE" /></SPAN>
-    </DIV>
+    <div class="act-title">
+      <span class="act-title">
+        <xsl:value-of select="TITLE" />: <xsl:value-of select="TITLE" />
+      </span>
+    </div>
     <xsl:apply-templates select="SCENE" />
   </xsl:template>
-  <!-- Displays list of play's characters -->
+  
   <xsl:template match="PERSONAE">
     <br />
     <br />
@@ -51,44 +57,31 @@
     <br />
     <br />
   </xsl:template>
-  <!-- Scope's scenes within the play -->
+  
   <xsl:template match="SCENE">
     <table>
       <tr>
-        <td width="15">
-        </td>
+        <td width="15"></td>
         <td width="100%">
-          <!-- The below code is somewhat funky.  Basically, the XML data is authored
-						     somewhat weird.  This is a work around that allows me to "go up and down"
-						     a different parent subtree
-						-->
-          <!-- Handle inner speeches and stage directions -->
           <xsl:apply-templates />
         </td>
       </tr>
     </table>
     <br />
   </xsl:template>
-  <!-- Display's an actor's lines -->
+  
   <xsl:template match="SPEECH">
     <br />
-    <!-- Note: I'm using the below table for tabbing purposes -->
     <table>
       <tr>
-        <!-- List speaker's name (in bold) -->
         <td valign="top" width="150">
-          <span STYLE="font-weight:bold; color:black">
+          <span class="speaker">
             <xsl:value-of select="SPEAKER" />:
           </span>
         </td>
-        <!-- The XML data is a little weird in that they break out individual lines of
-					     a character's speech, although the line tags *don't* correspond to pauses
-					     in the actor's speech.  With the XSL below I'm basically merging the
-					     lines into a single text block.
-					-->
         <td valign="top" width="400">
           <xsl:for-each select="LINE">
-            <span STYLE="color:black">
+            <span class="speaker">
               <xsl:value-of select="." />
             </span>
           </xsl:for-each>
@@ -96,21 +89,18 @@
       </tr>
     </table>
   </xsl:template>
-  <!-- Display's stage direction (ie: Hamlet enters from right...) -->
+  
   <xsl:template match="STAGEDIR">
     <br />
     <table>
       <tr>
         <td width="600">
-          <span STYLE="font-style:italic; color:black">
-            Stage Direction: <xsl:value-of select="." /></span>
+          <span class="stage-dir">
+            Stage Direction: <xsl:value-of select="." />
+          </span>
         </td>
       </tr>
     </table>
     <br />
-  </xsl:template>
-  <xsl:template match="SCNDESCR">
-  </xsl:template>
-  <xsl:template match="PLAYSUBT">
   </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
Added classes and updated CSS styles to improve readability and maintainability of the code.

Removed inline styling and moved the styles to the <style> section for better separation of concerns.

Fixed the duplicated TITLE element in the ACT template. Removed unused template matches for SCNDESCR and PLAYSUBT.