### PR TITLE
fix unhandled error occurs when loading a file with invalid XML forma…

### DIFF
--- a/src/Application/FormSchemas.cs
+++ b/src/Application/FormSchemas.cs
@@ -796,22 +796,36 @@ namespace XmlNotepad
             public XmlSchema LoadSchema(string filename)
             {
                 if (string.IsNullOrEmpty(filename)) return null;
-                using (var r = new XmlTextReader(filename, new NameTable()))
+                try 
                 {
-                    return XmlSchema.Read(r, (sender, args) =>
+                    using (var r = new XmlTextReader(filename, new NameTable()))
                     {
-                        if (args.Exception is XmlSchemaException se)
+                        return XmlSchema.Read(r, (sender, args) =>
                         {
-                            LogError($"{args.Message} See line {se.LineNumber} pos {se.LinePosition} of {se.SourceUri}");
-                        }
-                        else
-                        {
-                            LogError(args.Message);
-                        }
-                    });
+                            if (args.Exception is XmlSchemaException se)
+                            {
+                                this.LogError($"{args.Message} See line {se.LineNumber} pos {se.LinePosition} of {se.SourceUri}");
+                            }
+                            else
+                            {
+                                this.LogError(args.Message);
+                            }
+                        });
+                    }
+                }
+                catch (XmlException xe)
+                {
+                    // The files that do not meet the basic XML structure,
+                    // such as empty files or files with unclosed tags
+                    this.LogError($"{xe.Message} See line {xe.LineNumber} pos {xe.LinePosition} of {xe.SourceUri}");
+                    return null;
+                }
+                catch (Exception e)
+                {
+                    this.LogError(e.Message);
+                    return null;
                 }
             }
-
         }
 
         class SchemaDialogNewRow : SchemaDialogCommand


### PR DESCRIPTION
Hello,

I discovered that an unexpected error occurs when reading an empty file as the schema file in the schema dialog.
The cause of the occurrence was that XmlException was not taken into account when loading the schema file.
This is a minor improvement, as currently there is error checking when committing changes in the schema dialog.

I tested loading the invalid schema file below and verified that no unexpected errors occur (I verified that it goes through the exception path I added).
1. empty file
2. XSD file with unclosed XML tag
3. XSD file opened in another process