### PR TITLE
Embed CAB into installer

### DIFF
--- a/src/XmlNotepadSetup/Product.wxs
+++ b/src/XmlNotepadSetup/Product.wxs
@@ -3,7 +3,7 @@
   <Product Id="*" Name="XmlNotepad" Language="1033" Version="2.9.0.22" Manufacturer="Lovett Software" UpgradeCode="14C1B5E8-3198-4AF2-B4BC-351017A109D3">
     <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
     <MajorUpgrade Schedule="afterInstallFinalize" DowngradeErrorMessage="A newer version of [ProductName] is already installed." AllowSameVersionUpgrades="yes" />
-    <MediaTemplate />
+    <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="ProgramFilesFolder">
         <Directory Id="LovettSoftware" Name="LovettSoftware">


### PR DESCRIPTION
Motivation: The existing installer happily picks up my cab1.cab while retaining its code signature validity, and is otherwise less convenient than a self-contained one.